### PR TITLE
🔧 Add automated linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.0
+  browser-tools: circleci/browser-tools@1.4.3
 
 references:
   install_bundler: &install_bundler
@@ -16,6 +16,10 @@ references:
     run:
       name: Run the test suite
       command: COVERAGE=true bin/rake
+  run_linter: &run_linter
+    run:
+      name: Run the linter
+      command: standardrb
 
 jobs:
   build:
@@ -38,3 +42,4 @@ jobs:
       - <<: *install_bundler
       - <<: *setup
       - <<: *run_tests
+      - <<: *run_linter


### PR DESCRIPTION
There was no way for us to check our code styles without looking at
them.
We have added automated linting to run on the CI whenever we push a
commit.

