### PR TITLE
🔧 Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      internal: "daily"
+    labels: [ ]


### PR DESCRIPTION
We have added dependabot to automate the process of checking our
dependencies for us.
Previously, we had to check our dependencies ourselves.

