### PR TITLE
🐛 Fix typo in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,5 @@ updates:
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      internal: "daily"
+      interval: "daily"
     labels: [ ]


### PR DESCRIPTION
We had a typo in the dependabot configuration. This was stopping
dependabot from running.
We fixed the typo so that dependabot runs properly.
