### PR TITLE
🗑️ Drop unnecessary Bundler platforms

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,9 +137,7 @@ GEM
       rake
     globalid (1.0.0)
       activesupport (>= 5.0)
-    google-protobuf (3.24.0-arm64-darwin)
-    google-protobuf (3.24.0-x86_64-darwin)
-    google-protobuf (3.24.0-x86_64-linux)
+    google-protobuf (3.23.3)
     honeybadger (5.0.2)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
@@ -178,6 +176,7 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.4)
     minitest (5.16.0)
     msgpack (1.5.2)
     net-imap (0.2.3)
@@ -195,11 +194,8 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
-    nokogiri (1.13.6-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.6-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.6-x86_64-linux)
+    nokogiri (1.13.6)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     parallel (1.22.1)
     parser (3.1.2.1)
@@ -305,11 +301,7 @@ GEM
     stimulus-rails (1.0.4)
       railties (>= 6.0.0)
     strscan (3.0.3)
-    tailwindcss-rails (2.0.12-arm64-darwin)
-      railties (>= 6.0.0)
-    tailwindcss-rails (2.0.12-x86_64-darwin)
-      railties (>= 6.0.0)
-    tailwindcss-rails (2.0.12-x86_64-linux)
+    tailwindcss-rails (2.0.12)
       railties (>= 6.0.0)
     thor (1.2.1)
     timeout (0.3.0)
@@ -338,9 +330,7 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
-  arm64-darwin-20
-  x86_64-darwin-20
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   administrate!


### PR DESCRIPTION
Before, we included a bunch of Bundler platforms to allow us to package our Ruby gems across different operating systems. This specification is no longer necessary and started to cause issues with our CI service. We dropped the unnecessary Bundler platforms from the Gemfile.lock.