### PR TITLE
Bump circle ci browser tools from 1.4.3 to 1.4.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.3
+  browser-tools: circleci/browser-tools@1.4.5
 
 references:
   install_bundler: &install_bundler


### PR DESCRIPTION
This was done to fix the issue of the CI failing to build and we were getting an
error with the installed version of Google Chrome.
This change should fix the issue and the CI should build successfully.
