### PR TITLE
🐛 Change sign-in into a link

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,8 +60,8 @@
                     ) %>
                   </li>
                 <% else %>
-                  <li class="mb-1">
-                    <%= button_to(
+                  <li class="mb-1 mt-4">
+                    <%= link_to(
                       t(".sign_in"),
                       sign_in_path,
                       class: %w(


### PR DESCRIPTION
Previously, sign-in wasn't working. When clicked, nothing would happen.
It has been changed to be a link.
The sign-in link now works as expected when a user clicks on it.
