### PR TITLE
♻️  Improve edit button visibility

### DIFF
--- a/app/models/article_policy.rb
+++ b/app/models/article_policy.rb
@@ -1,0 +1,10 @@
+class ArticlePolicy
+  def initialize(user, article)
+    @article = article
+    @user = user
+  end
+
+  def edit?
+    @article.user == @user
+  end
+end

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -1,10 +1,12 @@
 <div class="max-w-lg rounded overflow-hidden shadow-xl p-10 mb-10">
   <p class="text-xl font-bold mb-2"><%= article.title %> </p>
   <p class="text-gray-700"><%= article.content %> </p>
-  <p class="text-gray-700 float-right">
-    <%= link_to t(".edit_article"), edit_article_path(article.id),
-    class: "border-b-2 border-purple-500 border-opacity-0
-    hover:border-opacity-100 hover:text-purple-500
-    duration-200 cursor-pointer active"%>
-  </p>
+  <% if ArticlePolicy.new(current_user, article).edit? %>
+    <p class="text-gray-700 float-right">
+      <%= link_to t(".edit_article"), edit_article_path(article.id),
+      class: "border-b-2 border-purple-500 border-opacity-0
+      hover:border-opacity-100 hover:text-purple-500
+      duration-200 cursor-pointer active"%>
+    </p>
+  <% end %>
 </div>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -3,12 +3,14 @@
     <div class="max-w-lg rounded overflow-hidden shadow-xl p-10 mb-10">
       <p class="text-xl font-bold mb-2"><%= article.title %> </p>
       <p class="text-gray-700"><%= article.content %> </p>
-      <p class="text-gray-700 float-right">
-        <%= link_to t(".edit_article"), edit_article_path(article.id),
-        class: "border-b-2 border-purple-500 border-opacity-0
-        hover:border-opacity-100 hover:text-purple-500
-        duration-200 cursor-pointer active"%>
-      </p>
+      <% if ArticlePolicy.new(current_user, article).edit? %>
+        <p class="text-gray-700 float-right">
+          <%= link_to t(".edit_article"), edit_article_path(article.id),
+          class: "border-b-2 border-purple-500 border-opacity-0
+          hover:border-opacity-100 hover:text-purple-500
+          duration-200 cursor-pointer active"%>
+        </p>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -8,7 +8,7 @@
 
     <p><%= @article.content %></p>
     <div class="space-y-4 flex text-center">
-      <% if @article.user == current_user %>
+      <% if ArticlePolicy.new(current_user, @article).edit? %>
         <%= link_to "Edit", edit_article_path(@article),
                     class: "purple-btn w-96" %>
       <% end %>

--- a/spec/models/article_policy_spec.rb
+++ b/spec/models/article_policy_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+RSpec.describe ArticlePolicy do
+  describe "#edit?" do
+    it "is false" do
+      user = create(:user)
+      other_user = create(:user)
+      article = create :article, user: other_user
+      article_policy = ArticlePolicy.new(user, article)
+
+      expect(article_policy.edit?).to be false
+    end
+
+    context "when the user is the author" do
+      it "is true" do
+        user = create(:user)
+        article = create :article, user: user
+        article_policy = ArticlePolicy.new(user, article)
+
+        expect(article_policy.edit?).to be true
+      end
+    end
+  end
+end

--- a/spec/system/author_visits_an_author_profile_spec.rb
+++ b/spec/system/author_visits_an_author_profile_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe "Author visits an author profile" do
+  context "the profile belongs to the author" do
+    it "shows an edit link" do
+      author = create(:user)
+      create :article, user: author
+
+      visit user_path(author, as: author)
+
+      expect(page).to have_content "Edit Article"
+    end
+  end
+  context "the profile doesn't belong to the author" do
+    it "doesn't show an edit link" do
+      author = create(:user)
+      somebody_else = create(:user)
+      create :article, user: somebody_else
+
+      visit user_path(somebody_else, as: author)
+
+      expect(page).not_to have_content "Edit Article"
+    end
+  end
+end

--- a/spec/system/guest_visits_an_author_profile_spec.rb
+++ b/spec/system/guest_visits_an_author_profile_spec.rb
@@ -13,5 +13,6 @@ RSpec.describe "Guest visits an author profile" do
     expect(page).to have_content "TEST_ARTICLE_1"
     expect(page).to have_content "TEST_ARTICLE_2"
     expect(page).not_to have_content "TEST_ARTICLE_3"
+    expect(page).not_to have_content "Edit Article"
   end
 end

--- a/spec/system/guest_visits_the_home_page_spec.rb
+++ b/spec/system/guest_visits_the_home_page_spec.rb
@@ -9,5 +9,6 @@ RSpec.describe "Guest visits the home page" do
 
     expect(page).to have_content "TEST_ARTICLE_1"
     expect(page).to have_content "TEST_ARTICLE_2"
+    expect(page).not_to have_content "Edit Article"
   end
 end


### PR DESCRIPTION
Previously, the edit button was present on every article card.
We have now enhanced it to only display for the author of the
article.
This modification reduces confusion, ensuring users can only edit
articles they have authored.
