### PR TITLE
✨ Add articles link on the header

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,8 @@ class User < ApplicationRecord
   include Clearance::User
 
   has_many :articles
+
+  def user_name
+    email.gsub(/@.*$/, "")
+  end
 end

--- a/app/views/application/_greeting.en.html.erb
+++ b/app/views/application/_greeting.en.html.erb
@@ -1,0 +1,4 @@
+<div class="link border-b-transparent p-4">
+  Hello: <%= link_to(current_user.user_name, user_path(current_user),
+                     class: "hover:text-purple-500 hover:underline") %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,26 +25,28 @@
               <ul class="flex items-center">
                 <% if signed_in? %>
                   <li class="mb-1">
-                    <%= t(".greeting", email: current_user.email) %>
+                    <%= render partial: "greeting" %>
                   </li>
-                  <div x-data="{ open: false }">
-                    <button @click="open = !open" class="link
-                                    hover:border-opacity-100
-                                    hover:text-purple-500
-                                    duration-200 cursor-pointer active">
-                      <%= t(".articles") %>
-                    </button>
-                    <div x-show="open" class="drop-down">
-                      <ul id="accordion">
+                  <li class="mb-1">
+                    <div x-data="{ open: false }">
+                      <button @click="open = !open" class="link
+                                      hover:border-opacity-100
+                                      hover:text-purple-500
+                                      duration-200 cursor-pointer active">
+                        <%= t(".articles") %>
+                      </button>
+                      <div x-show="open" class="drop-down">
+                        <ul id="accordion">
+                          <li class="li-item">
+                            <%= link_to t(".view_articles"), articles_path %>
+                          </li>
                         <li class="li-item">
-                          <%= link_to t(".view_articles"), articles_path %>
+                          <%= link_to t(".create_article"), new_article_path %>
                         </li>
-                       <li class="li-item">
-                         <%= link_to t(".create_article"), new_article_path %>
-                       </li>
-                     </ul>
+                      </ul>
+                      </div>
                     </div>
-                  </div>
+                  </li>
                   <li class="mb-1">
                     <%= button_to(
                       t(".sign_out"),


### PR DESCRIPTION
Formerly, signed-in users had to navigate through a drop down menu in
order to access their created articles.
Now, this information is directly accessible from the header.
This enhancement simplifies the process for users to navigate to their
created articles.

