### PR TITLE
♻️  Change articles link

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,9 +1,3 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
-import Alpine from "alpinejs"
-window.Alpine = Alpine
-
-document.addEventListener("DOMContentLoaded", function(event){
-  window.Alpine.start();
-});

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,25 +27,10 @@
                   <li class="mb-1">
                     <%= render partial: "greeting" %>
                   </li>
-                  <li class="mb-1">
-                    <div x-data="{ open: false }">
-                      <button @click="open = !open" class="link
-                                      hover:border-opacity-100
-                                      hover:text-purple-500
-                                      duration-200 cursor-pointer active">
-                        <%= t(".articles") %>
-                      </button>
-                      <div x-show="open" class="drop-down">
-                        <ul id="accordion">
-                          <li class="li-item">
-                            <%= link_to t(".view_articles"), articles_path %>
-                          </li>
-                        <li class="li-item">
-                          <%= link_to t(".create_article"), new_article_path %>
-                        </li>
-                      </ul>
-                      </div>
-                    </div>
+                  <li class="mb-1 link hover:border-opacity-100
+                             hover:text-purple-500 duration-200
+                             cursor-pointer active">
+                    <%= link_to t(".new_article"), new_article_path %>
                   </li>
                   <li class="mb-1">
                     <%= button_to(

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -5,4 +5,3 @@ pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
-pin "alpinejs", to: "https://ga.jspm.io/npm:alpinejs@3.12.2/dist/module.esm.js"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,7 +57,7 @@ en:
   layouts:
     application:
       articles: "Articles"
-      create_article: "Create Article"
+      new_article: "New Article"
       greeting: "Hello: %{email}"  
       title: "Rumblr"
       view_articles: "View Articles"


### PR DESCRIPTION
Previously, signed-in users had to navigate through a drop-down menu to
view and create articles.
We've streamlined this process by introducing a direct link to the new
article page.
This change aims to simplify navigation and minimize the reliance on
JavaScript.
