### PR TITLE
✨ Add name field to the sign-up form

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -3,3 +3,4 @@ FROM_EMAIL=sample@test.com
 HONEYBADGER_API_KEY=honeybadger
 ADMIN_EMAIL=admin@test.com
 ADMIN_PASSWORD=test
+ADMIN_NAME=Admin

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,4 +4,16 @@ class UsersController < Clearance::UsersController
   def show
     @user = User.find(params[:id])
   end
+
+  def user_from_params
+    email = user_params.delete(:email)
+    password = user_params.delete(:password)
+    name = user_params.delete(:name)
+
+    Clearance.configuration.user_model.new(user_params).tap do |user|
+      user.email = email
+      user.password = password
+      user.name = name
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,5 @@ class User < ApplicationRecord
 
   has_many :articles
 
-  def user_name
-    email.gsub(/@.*$/, "")
-  end
+  validates :name, presence: true
 end

--- a/app/views/application/_greeting.en.html.erb
+++ b/app/views/application/_greeting.en.html.erb
@@ -1,4 +1,4 @@
 <div class="link border-b-transparent p-4">
-  Hello: <%= link_to(current_user.user_name, user_path(current_user),
+  Hello: <%= link_to(current_user.name, user_path(current_user),
                      class: "hover:text-purple-500 hover:underline") %>
 </div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,5 +1,11 @@
 <div class="text-field">
-  <%= form.label :email, class: "block font-semibold" %>
+  <%= form.label :name, class: "block font-semibold" %>
+  <%= form.text_field :name, class: "email-input", placeholder: "Name"%>
+  <%= field_with_errors(@user, :name) %>
+</div>
+
+<div class="text-field">
+  <%= form.label :email, class: "block mt-3 font-semibold" %>
   <%= form.email_field :email, class: "email-input", placeholder: "Email"%>
   <%= field_with_errors(@user, :email) %>
 </div>

--- a/db/migrate/20231201104328_add_name_to_users.rb
+++ b/db/migrate/20231201104328_add_name_to_users.rb
@@ -1,0 +1,5 @@
+class AddNameToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_07_085338) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_01_104328) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -31,6 +31,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_07_085338) do
     t.string "confirmation_token", limit: 128
     t.string "remember_token", limit: 128, null: false
     t.boolean "admin", default: false
+    t.string "name"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email"
     t.index ["remember_token"], name: "index_users_on_remember_token", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,5 +8,6 @@
 
 unless User.exists?(admin: true)
   User.create!(email: ENV.fetch("ADMIN_EMAIL"),
-    password: ENV.fetch("ADMIN_PASSWORD"), admin: true)
+    password: ENV.fetch("ADMIN_PASSWORD"), name: ENV.fetch("ADMIN_NAME"),
+    admin: true)
 end

--- a/spec/factories/clearance.rb
+++ b/spec/factories/clearance.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
   factory :user do
     email
     password { "password" }
+    name { "Test User" }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,4 +4,8 @@ RSpec.describe User do
   describe "associations" do
     it { is_expected.to have_many(:articles) }
   end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+  end
 end

--- a/spec/support/features/clearance_helpers.rb
+++ b/spec/support/features/clearance_helpers.rb
@@ -23,10 +23,11 @@ module Features
       click_button I18n.t("layouts.application.sign_out")
     end
 
-    def sign_up_with(email, password)
+    def sign_up_with(email, password, name = "Test Name")
       visit sign_up_path
       fill_in "user_email", with: email
       fill_in "user_password", with: password
+      fill_in "user_name", with: name
       click_button I18n.t("helpers.submit.user.create")
     end
 

--- a/spec/system/clearance/visitor_signs_up_spec.rb
+++ b/spec/system/clearance/visitor_signs_up_spec.rb
@@ -10,10 +10,11 @@ RSpec.feature "Visitor signs up" do
     expect(current_path).to eq sign_up_path
   end
 
-  scenario "with valid email and password" do
-    sign_up_with "valid@example.com", "password"
+  scenario "with valid email, password and name" do
+    sign_up_with "valid@example.com", "password", "John Doe"
 
     expect_user_to_be_signed_in
+    expect(page).to have_content("Hello: John Doe")
   end
 
   scenario "tries with invalid email" do


### PR DESCRIPTION
Previously, the sign-up form collected only the user's email and
password.

We have extended this functionality to include the user's name.
This update enables us to personalize the user greeting upon sign-in
with their name.

