### PR TITLE
🎨 Change success alert colour to green

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -20,12 +20,10 @@
     flex-col justify-center overflow-hidden bg-gray-50 py-6 sm:py-12;
   }
   .flash-notice {
-    @apply bg-green-300 text-green-900;
+    @apply bg-green-100 border border-green-400 text-green-700
+    px-4 py-3 w-fit rounded relative;
   }
   .flash-alert {
-    @apply bg-red-300 text-red-900;
-  }
-  .flash {
     @apply bg-red-100 border border-red-400 text-red-700
     px-4 py-3 w-fit rounded relative;
   }

--- a/app/views/application/_flashes.html.erb
+++ b/app/views/application/_flashes.html.erb
@@ -1,8 +1,10 @@
 <% if flash.any? %>
   <div class="center-div">
-    <div class="flash" role="alert">
+    <div role="alert">
       <% user_facing_flashes.each do |key, value| -%>
-        <div class="font-bold flash-<%= key %>"><%= value %></div>
+        <div class="font-bold <%= key == 'notice' ? 'flash-notice' :
+          'flash-alert' %>"><%= value %>
+        </div>
       <% end -%>
     </div>
   </div>


### PR DESCRIPTION
Previously, the success alert appeared in red, causing visual confusion as it closely resembled the error alert.
We have changed the success alert colour to green to eliminate any potential confusion.

Older red success alert:

![Red success alert](https://github.com/thoughtbot/rumblr/assets/3297508/e650f3c7-556f-48ce-a160-50edf6e12f3d)

New green success alert:

![Green success alert](https://github.com/thoughtbot/rumblr/assets/3297508/a61e3404-94c3-4249-a123-9abc89461058)
