### PR TITLE
🐛 Fix author link

### DIFF
--- a/app/views/application/_greeting.en.html.erb
+++ b/app/views/application/_greeting.en.html.erb
@@ -1,4 +1,4 @@
 <div class="link border-b-transparent p-4">
-  Hello: <%= link_to(current_user.name, user_path(current_user),
+  Hello: <%= link_to(current_user.name, author_path(current_user),
                      class: "hover:text-purple-500 hover:underline") %>
 </div>


### PR DESCRIPTION
Previously, this was pointing to the user path and causing an unknown action error.
This has been fixed to point to the author path.
This gets rid of the error.
