### PR TITLE
Update `.sample.env`

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -1,3 +1,6 @@
+ADMIN_EMAIL=admin@example.com
+ADMIN_NAME=Administrator
+ADMIN_PASSWORD=password
 EMAIL_RECIPIENTS=test@test.com
 FROM_EMAIL=sample@test.com
 HONEYBADGER_API_KEY=honeybadger


### PR DESCRIPTION
`.sample.env` is copied to `.env` when running `bin/setup`. However, some environment variables are not set and then have to be added manually.

This commit updates `.sample.env` with example values for the missing environment variables to make it easier to set up this project after the initial clone.